### PR TITLE
Update the `$PYENV_ROOT/bin` to `.../shims`

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ easy to fork and contribute any changes back upstream.
         
         ~~~ fish
         set -Ux PYENV_ROOT $HOME/.pyenv
-        set -U fish_user_paths $PYENV_ROOT/bin $fish_user_paths
+        set -U fish_user_paths $PYENV_ROOT/shims $fish_user_paths
         ~~~
 
         And add this to `~/.config/fish/config.fish`:


### PR DESCRIPTION
There is no `bin` folder under `$PYENV_ROOT/`. It should be `$PYENV_ROOT/shims. 

If keep it as `bin`, the `rbenv` will not be set correctly for fish user.

